### PR TITLE
suggested fixes for check_recall()

### DIFF
--- a/R/write_scrape_test_searches.R
+++ b/R/write_scrape_test_searches.R
@@ -554,7 +554,9 @@ scrape_openthesis <- function(search_terms=NULL, URL=NULL, writefile=FALSE, verb
 #' @return a table of the best match for each true title from the search results along with a title similarity score
 #' @example inst/examples/check_recall.R
 check_recall <- function (true_hits, retrieved) {
-  matches <- lapply(tm::removePunctuation(tolower(true_hits)), synthesisr::fuzzdist, b=tm::removePunctuation(tolower(retrieved)))
+  matches <- lapply(litsearchr::remove_punctuation(tolower(true_hits), preserve_punctuation=c("-")),
+                    synthesisr::fuzzdist,
+                    b=litsearchr::remove_punctuation(tolower(retrieved), preserve_punctuation=c("-")))
   similarity_table <- cbind(true_hits, retrieved[unlist(lapply(matches, which.min))], 1-unlist(lapply(matches, min, na.rm=TRUE)))
   colnames(similarity_table) <- c("Title", "Best_Match", "Similarity")
   return(similarity_table)

--- a/R/write_scrape_test_searches.R
+++ b/R/write_scrape_test_searches.R
@@ -557,7 +557,8 @@ check_recall <- function (true_hits, retrieved) {
   matches <- lapply(litsearchr::remove_punctuation(tolower(true_hits), preserve_punctuation=c("-")),
                     synthesisr::fuzzdist,
                     b=litsearchr::remove_punctuation(tolower(retrieved), preserve_punctuation=c("-")))
-  similarity_table <- cbind(true_hits, retrieved[unlist(lapply(matches, which.min))], 1-unlist(lapply(matches, min, na.rm=TRUE)))
-  colnames(similarity_table) <- c("Title", "Best_Match", "Similarity")
+  similarity_table <- data.frame(Title = true_hits,
+                                 Best_Match = retrieved[unlist(lapply(matches, which.min))],
+                                 Similarity = 1-unlist(lapply(matches, min, na.rm=TRUE)))
   return(similarity_table)
 }


### PR DESCRIPTION
beb0e7e572cb86caaf35d08ff958bdc1648b36f6 for #47 
Hyphens are now exempted from removing punctuation, which preserves the character alignment of hyphenated vs. non-hyphenated variants ('black-backed' vs. 'black backed', 'cognitive-behavioral' vs. 'cognitive behavioral', etc.) There is perhaps a reasonable alternative here, which is to instead replace hyphens with spaces, so maybe think about this one first and feel free to reject it if you have a different preference.

d0c490722796eb1d34cef708a473b2177c610d07 for #48
Now returns a dataframe instead of a character matrix. I think this is fairly uncontroversially better but of course changing the type of a return value is a potentially breaking change if people are already depending on the matrix behavior in their code.