### PR TITLE
Add dependency for newer version of synthesisr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     utils,
     igraph,
     ngram,
-    synthesisr,
+    synthesisr (>= 0.3),
     stopwords,
     tm
 Suggests: 


### PR DESCRIPTION
Hi @elizagrames,

Hope the summer is going well for you - or as well as possible given the circumstances!

A very small thing for you - `litsearchr` seems to depend on the newest version of `synthesisr` (>=0.3.0) but this is not declared in the `DESCRIPTION`. I only discovered it when I was playing around with the development version of `litsearchr` and got an error in one of the functions:
``` r
litsearchr::remove_duplicates(naiveimport,
                                 field = "title",
                                 method = "string_osa")
```
```
Error in synthesisr::find_duplicates(data = df, match_variable = field,  : 
  unused argument (match_variable = field)
```

I went investigating, and it turns out that I had version 0.2.0 of `synthesisr` installed from ages ago - updating it to the newer version fixed the issue.

I've added the version dependency in this PR to try and reduce your workload - hope that's okay/helpful!
